### PR TITLE
Fix remoting spec.  remaining issues:

### DIFF
--- a/specification/registry/xr.xml
+++ b/specification/registry/xr.xml
@@ -1336,7 +1336,7 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         <!-- XR_MSFT_remoting -->
         <type name="XrRemotingDisconnectReasonMSFT" category="enum"/>
         <type name="XrRemotingConnectionStateMSFT" category="enum"/>
-        <type name="XrRemotingPreferredVideoCodecMSFT" category="enum"/>
+        <type name="XrRemotingVideoCodecMSFT" category="enum"/>
         <type name="XrRemotingCertificateNameMismatchMSFT" category="enum"/>
 
         <type category="struct" name="XrRemotingRemoteContextPropertiesMSFT">
@@ -1889,14 +1889,14 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         <enum value="2" name="XR_REMOTING_CONNECTION_STATE_CONNECTED_MSFT"/>
     </enums>
     <enums name="XrRemotingVideoCodecMSFT" type="enum">
-        <enum value="0" name="XR_REMOTING_VIDEO_CODEC_ANY"/>
-        <enum value="1" name="XR_REMOTING_VIDEO_CODEC_H264"/>
-        <enum value="2" name="XR_REMOTING_VIDEO_CODEC_H265"/>
+        <enum value="0" name="XR_REMOTING_VIDEO_CODEC_ANY_MSFT"/>
+        <enum value="1" name="XR_REMOTING_VIDEO_CODEC_H264_MSFT"/>
+        <enum value="2" name="XR_REMOTING_VIDEO_CODEC_H265_MSFT"/>
     </enums>
     <enums name="XrRemotingCertificateNameMismatchMSFT" type="enum">
-        <enum value="0" name="XR_REMOTING_CERTIFICATE_NAME_NOT_CHECKED"/>
-        <enum value="1" name="XR_REMOTING_CERTIFICATE_NAME_MATCH"/>
-        <enum value="2" name="XR_REMOTING_CERTIFICATE_NAME_MISMATCH"/>
+        <enum value="0" name="XR_REMOTING_CERTIFICATE_NAME_MISMATCH_NOT_CHECKED_MSFT"/>
+        <enum value="1" name="XR_REMOTING_CERTIFICATE_NAME_MISMATCH_MATCH_MSFT"/>
+        <enum value="2" name="XR_REMOTING_CERTIFICATE_NAME_MISMATCH_MISMATCH_MSFT"/>
     </enums>
 
     <!-- SECTION: OpenXR command definitions -->
@@ -2550,44 +2550,44 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         </command>
       
         <!-- XR_MSFT_remoting -->
-        <command successcodes="XR_SUCCESS">
+        <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_HANDLE_INVALID,XR_ERROR_INSTANCE_LOST,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_SYSTEM_INVALID,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_FUNCTION_UNSUPPORTED">
             <proto><type>XrResult</type> <name>xrRemotingSetContextPropertiesMSFT</name></proto>
             <param><type>XrInstance</type> <name>instance</name></param>
             <param><type>XrSystemId</type> <name>systemId</name></param>
             <param>const <type>XrRemotingRemoteContextPropertiesMSFT</type>* <name>contextProperties</name></param>
         </command>
-      <command successcodes="XR_SUCCESS">
+      <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_HANDLE_INVALID,XR_ERROR_INSTANCE_LOST,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_SYSTEM_INVALID,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_FUNCTION_UNSUPPORTED">
             <proto><type>XrResult</type> <name>xrRemotingConnectMSFT</name></proto>
             <param><type>XrInstance</type> <name>instance</name></param>
             <param><type>XrSystemId</type> <name>systemId</name></param>
             <param>const <type>XrRemotingConnectInfoMSFT</type>* <name>connectInfo</name></param>
         </command>
-      <command successcodes="XR_SUCCESS">
+      <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_HANDLE_INVALID,XR_ERROR_INSTANCE_LOST,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_SYSTEM_INVALID,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_FUNCTION_UNSUPPORTED">
             <proto><type>XrResult</type> <name>xrRemotingListenMSFT</name></proto>
             <param><type>XrInstance</type> <name>instance</name></param>
             <param><type>XrSystemId</type> <name>systemId</name></param>
             <param>const <type>XrRemotingListenInfoMSFT</type>* <name>listenInfo</name></param>
         </command>
-      <command successcodes="XR_SUCCESS">
+      <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_HANDLE_INVALID,XR_ERROR_INSTANCE_LOST,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_SYSTEM_INVALID,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_FUNCTION_UNSUPPORTED">
             <proto><type>XrResult</type> <name>xrRemotingDisconnectMSFT</name></proto>
             <param><type>XrInstance</type> <name>instance</name></param>
             <param><type>XrSystemId</type> <name>systemId</name></param>
             <param>const <type>XrRemotingDisconnectInfoMSFT</type>* <name>disconnectInfo</name></param>
         </command>
-      <command successcodes="XR_SUCCESS">
+      <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_HANDLE_INVALID,XR_ERROR_INSTANCE_LOST,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_SYSTEM_INVALID,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_FUNCTION_UNSUPPORTED">
             <proto><type>XrResult</type> <name>xrRemotingGetConnectionStateMSFT</name></proto>
             <param><type>XrInstance</type> <name>instance</name></param>
             <param><type>XrSystemId</type> <name>systemId</name></param>
             <param><type>XrRemotingConnectionStateMSFT</type>* <name>connectionState</name></param>
             <param><type>XrRemotingDisconnectReasonMSFT</type>* <name>lastDisconnectReason</name></param>
         </command>
-      <command successcodes="XR_SUCCESS">
+      <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_HANDLE_INVALID,XR_ERROR_INSTANCE_LOST,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_SYSTEM_INVALID,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_FUNCTION_UNSUPPORTED">
             <proto><type>XrResult</type> <name>xrRemotingSetSecureConnectionClientCallbacksMSFT</name></proto>
             <param><type>XrInstance</type> <name>instance</name></param>
             <param><type>XrSystemId</type> <name>systemId</name></param>
             <param>const <type>XrRemotingSecureConnectionClientCallbacksMSFT</type>* <name>secureConnectionClientCallbacks</name></param>
         </command>
-      <command successcodes="XR_SUCCESS">
+      <command successcodes="XR_SUCCESS" errorcodes="XR_ERROR_HANDLE_INVALID,XR_ERROR_INSTANCE_LOST,XR_ERROR_RUNTIME_FAILURE,XR_ERROR_SYSTEM_INVALID,XR_ERROR_VALIDATION_FAILURE,XR_ERROR_FUNCTION_UNSUPPORTED">
             <proto><type>XrResult</type> <name>xrRemotingSetSecureConnectionServerCallbacksMSFT</name></proto>
             <param><type>XrInstance</type> <name>instance</name></param>
             <param><type>XrSystemId</type> <name>systemId</name></param>
@@ -3389,13 +3389,6 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         </require>
     </extension>
 
-    <extension name="XR_MSFT_extension_66" number="66" type="instance" supported="disabled">
-        <require>
-            <enum value="1" name="XR_MSFT_extension_66_SPEC_VERSION"/>
-            <enum value="&quot;XR_MSFT_extension_66&quot;" name="XR_MSFT_extension_66_EXTENSION_NAME"/>
-        </require>
-    </extension>
-
     <extension name="XR_MSFT_extension_67" number="67" type="instance" supported="disabled">
         <require>
             <enum value="1" name="XR_MSFT_extension_67_SPEC_VERSION"/>
@@ -3655,12 +3648,6 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
             <enum value="&quot;XR_MSFT_extension_100&quot;" name="XR_MSFT_extension_100_EXTENSION_NAME"/>
         </require>
     </extension>
-    <extension name="XR_MSFT_extension_101" number="101" type="instance" supported="disabled">
-        <require>
-            <enum value="1" name="XR_MSFT_extension_101_SPEC_VERSION"/>
-            <enum value="&quot;XR_MSFT_extension_101&quot;" name="XR_MSFT_extension_101_EXTENSION_NAME"/>
-        </require>
-    </extension>
 
     <extension name="XR_MSFT_remoting" number="66" type="instance" supported="openxr">
         <require>
@@ -3677,7 +3664,7 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
 
             <type name="XrRemotingDisconnectReasonMSFT"/>
             <type name="XrRemotingConnectionStateMSFT"/>
-            <type name="XrRemotingPreferredVideoCodecMSFT"/>
+            <type name="XrRemotingVideoCodecMSFT"/>
             <type name="XrRemotingCertificateNameMismatchMSFT"/>
           
             <type name="XrRemotingRemoteContextPropertiesMSFT"/>
@@ -3718,7 +3705,7 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         </require>
     </extension>
 
-      <extension name="XR_MSFT_remoting_frame_mirroring" number="101" type="instance" supported="openxr">
+      <extension name="XR_MSFT_remoting_frame_mirroring" number="101" type="instance" supported="openxr" protect="XR_USE_GRAPHICS_API_D3D11">
         <require>
           <enum value="1" name="XR_MSFT_remoting_frame_mirroring_SPEC_VERSION"/>
           <enum value="&quot;XR_MSFT_remoting_frame_mirroring&quot;" name="XR_MSFT_REMOTING_FRAME_MIRRORING_EXTENSION_NAME"/>

--- a/specification/sources/chapters/extensions/msft/msft_remoting.adoc
+++ b/specification/sources/chapters/extensions/msft/msft_remoting.adoc
@@ -29,9 +29,9 @@ Setting up a remoting connection requires some extra steps in the OpenXR initial
 If the application does not wait for a successful connection before creating a session, session creation will block 
 until either a connection has been established or the connection attempt has failed.
 
-Note that some player device properties, such as slink:XrViewConfigurationType and slink:XrEnvironmentBlendMode,
+Note that some player device properties, such as elink:XrViewConfigurationType and elink:XrEnvironmentBlendMode,
 can only return actual values after a remoting connection has been established. Before this point, default values 
-are returned for these properties. The recommended approach is therefore to create the XrSession 
+are returned for these properties. The recommended approach is therefore to create the slink:XrSession 
 before enumerating the device properties.
 
 [open,refpage='XrRemotingRemoteContextPropertiesMSFT',desc='Properties of the Remote Context',type='structs',xrefs='XrRemotingVideoCodecMSFT']
@@ -51,6 +51,9 @@ include::../../../../generated/api/structs/XrRemotingRemoteContextPropertiesMSFT
 * pname:videoCodec is the video codec to use for the connection.
 ****
 
+include::../../../../generated/validity/structs/XrRemotingRemoteContextPropertiesMSFT.txt[]
+--
+
 [open,refpage='XrRemotingConnectInfoMSFT',desc='Describes how the remote, in network client mode, should connect to a player running in network server mode',type='structs']
 --
 The slink:XrRemotingConnectInfoMSFT structure is defined as:
@@ -67,6 +70,9 @@ include::../../../../generated/api/structs/XrRemotingConnectInfoMSFT.txt[]
 * pname:remotePort is the port number of the server's handshake port.
 * pname:secureConnection states whether an encrypted and authenticated connection method is to be used for the connection.
 ****
+
+include::../../../../generated/validity/structs/XrRemotingConnectInfoMSFT.txt[]
+--
 
 [open,refpage='XrRemotingListenInfoMSFT',desc='Describes how the remote, in network server mode, should listen to connections from a player running in network client mode',type='structs']
 --
@@ -86,6 +92,9 @@ include::../../../../generated/api/structs/XrRemotingListenInfoMSFT.txt[]
 * pname:secureConnection states whether an encrypted and authenticated connection method is to be used for the connection.
 ****
 
+include::../../../../generated/validity/structs/XrRemotingListenInfoMSFT.txt[]
+--
+
 [open,refpage='XrRemotingDisconnectInfoMSFT',desc='Describes how to close the current connection',type='structs']
 --
 The slink:XrRemotingDisconnectInfoMSFT structure is defined as:
@@ -99,6 +108,9 @@ include::../../../../generated/api/structs/XrRemotingDisconnectInfoMSFT.txt[]
   chain.
   No such structures are defined in core OpenXR or this extension.
 ****
+
+include::../../../../generated/validity/structs/XrRemotingDisconnectInfoMSFT.txt[]
+--
 
 [open,refpage='XrRemotingEventDataListeningMSFT',desc='Describes the connection properties when the system enters the network listening state',type='structs']
 --
@@ -115,6 +127,9 @@ include::../../../../generated/api/structs/XrRemotingEventDataListeningMSFT.txt[
 * pname:listeningPort is the port number the remote is listening on.
 ****
 
+include::../../../../generated/validity/structs/XrRemotingEventDataListeningMSFT.txt[]
+--
+
 [open,refpage='XrRemotingEventDataConnectedMSFT',desc='Indicates that a connection has been established and describes its properties',type='structs']
 --
 The slink:XrRemotingEventDataConnectedMSFT structure is defined as:
@@ -128,6 +143,9 @@ include::../../../../generated/api/structs/XrRemotingEventDataConnectedMSFT.txt[
   chain.
   No such structures are defined in core OpenXR or this extension.
 ****
+
+include::../../../../generated/validity/structs/XrRemotingEventDataConnectedMSFT.txt[]
+--
 
 [open,refpage='XrRemotingEventDataDisconnectedMSFT',desc='Describes that a disconnect has occured',type='structs']
 --
@@ -143,6 +161,9 @@ include::../../../../generated/api/structs/XrRemotingEventDataDisconnectedMSFT.t
   No such structures are defined in core OpenXR or this extension.
 * pname:disconnectReason is the reason why the disconnect happened.
 ****
+
+include::../../../../generated/validity/structs/XrRemotingEventDataDisconnectedMSFT.txt[]
+--
 
 [open,refpage='XrRemotingAuthenticationTokenRequestMSFT',desc='Describes a request for an authentication token to be passed to the server as part of the secure connection process',type='structs']
 --
@@ -163,6 +184,9 @@ please refer to : https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.
 The value written to tokenBuffer is expected to be a null-terminated string.
 ****
 
+include::../../../../generated/validity/structs/XrRemotingAuthenticationTokenRequestMSFT.txt[]
+--
+
 [open,refpage='XrRemotingCertificateDataMSFT',desc='Data for one of the certificates from the certificate chain of a certificate validation request',type='structs']
 --
 The slink:XrRemotingCertificateDataMSFT structure is defined as:
@@ -178,6 +202,9 @@ include::../../../../generated/api/structs/XrRemotingCertificateDataMSFT.txt[]
 * pname:size is the size of the certificate data
 * pname:data is the pointer to the certificate data
 ****
+
+include::../../../../generated/validity/structs/XrRemotingCertificateDataMSFT.txt[]
+--
 
 [open,refpage='XrRemotingCertificateValidationResultMSFT',desc='The result of a certificate validation',type='structs']
 --
@@ -201,6 +228,9 @@ include::../../../../generated/api/structs/XrRemotingCertificateValidationResult
 * pname:invalidCertOrChain states whether the certificate to validate and/or certificate(s) in the certificate chain contained invalid data and could not be examined
 ****
 
+include::../../../../generated/validity/structs/XrRemotingCertificateValidationResultMSFT.txt[]
+--
+
 [open,refpage='XrRemotingServerCertificateValidationMSFT',desc='Details of a certificate validation request and the resultant outcome',type='structs']
 --
 The slink:XrRemotingServerCertificateValidationMSFT structure is defined as:
@@ -222,6 +252,9 @@ include::../../../../generated/api/structs/XrRemotingServerCertificateValidation
 * pname:validationResultOut is the result of the certificate validation request
 ****
 
+include::../../../../generated/validity/structs/XrRemotingServerCertificateValidationMSFT.txt[]
+--
+
 [open,refpage='XrRemotingAuthenticationTokenValidationMSFT',desc='Details of a token validation request and the resultant outcome',type='structs']
 --
 The slink:XrRemotingAuthenticationTokenValidationMSFT structure is defined as:
@@ -238,6 +271,9 @@ include::../../../../generated/api/structs/XrRemotingAuthenticationTokenValidati
 * pname:token is the passed in authentication token
 * pname:tokenValidOut indicates whether the validation result passed
 ****
+
+include::../../../../generated/validity/structs/XrRemotingAuthenticationTokenValidationMSFT.txt[]
+--
 
 [open,refpage='XrRemotingServerCertificateRequestMSFT',desc='Describes a server certificate request and output buffers to store the corresponding data in',type='structs']
 --
@@ -269,6 +305,9 @@ For more details regarding the handling of buffer size parameters in OpenXR,
 please refer to : https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#buffer-size-parameters
 ****
 
+include::../../../../generated/validity/structs/XrRemotingServerCertificateRequestMSFT.txt[]
+--
+
 [open,refpage='XrRemotingSecureConnectionServerCallbacksMSFT',desc='Describes a callback interface for certificate requests and authentication token validation on the server',type='structs']
 --
 The slink:XrRemotingSecureConnectionServerCallbacksMSFT structure is defined as:
@@ -286,6 +325,9 @@ include::../../../../generated/api/structs/XrRemotingSecureConnectionServerCallb
 * pname:validateAuthenticationTokenCallback is the callback interface that needs to be passed when the server network context needs to validate a client's authentication token
 * pname:authenticationRealm is the name of the current authentication realm
 ****
+
+include::../../../../generated/validity/structs/XrRemotingSecureConnectionServerCallbacksMSFT.txt[]
+--
 
 [open,refpage='XrRemotingSecureConnectionClientCallbacksMSFT',desc='Describes a callback interface for certificate validation and authentication token requests on the client.',type='structs']
 --
@@ -305,6 +347,8 @@ include::../../../../generated/api/structs/XrRemotingSecureConnectionClientCallb
 * pname:peformSystemValidation states whether to request validation of the server's certificate using the validation functions of the underlying operating system or cryptography library.
 ****
 
+include::../../../../generated/validity/structs/XrRemotingSecureConnectionClientCallbacksMSFT.txt[]
+--
 
 *Set the properties of the Remote Context*
 
@@ -316,7 +360,7 @@ include::../../../../generated/api/protos/xrRemotingSetContextPropertiesMSFT.txt
 .Parameter Descriptions
 ****
 * pname:instance is the handle of the instance from which to get the information
-* pname:systemId is the slink:XrSystemId of the current system 
+* pname:systemId is the basetype:XrSystemId of the current system 
 * pname:contextProperties is the remote context properties like the max bitrate, video codec etc. to use for the connection.
 ****
 
@@ -325,17 +369,17 @@ This configuration must happen before the actual connection attempt in flink:xrR
 include::../../../../generated/validity/protos/xrRemotingSetContextPropertiesMSFT.txt[]
 --
 
-*Connect to a player running in network server mode with/without using an encrypted and authenticated connection method as requested in the slink:XrRemotingConnectInfoMSFT*
-
 [open,refpage='xrRemotingConnectMSFT',type='protos',desc='Connect to a player running in network server mode with/without using an encrypted and authenticated connection method as requested in the slink:XrRemotingConnectInfoMSFT',xrefs='XrRemotingConnectInfoMSFT']
 --
+
+Connect to a player running in network server mode with/without using an encrypted and authenticated connection method as requested in the slink:XrRemotingConnectInfoMSFT.
 
 include::../../../../generated/api/protos/xrRemotingConnectMSFT.txt[]
 
 .Parameter Descriptions
 ****
 * pname:instance is the handle of the instance from which to get the information
-* pname:systemId is the slink:XrSystemId of the current system 
+* pname:systemId is the basetype:XrSystemId of the current system 
 * pname:connectInfo is the slink:XrRemotingConnectInfoMSFT properties/settings to use for the connection
 ****
 
@@ -354,7 +398,7 @@ include::../../../../generated/api/protos/xrRemotingListenMSFT.txt[]
 .Parameter Descriptions
 ****
 * pname:instance is the handle of the instance from which to get the information
-* pname:systemId is the slink:XrSystemId of the current system 
+* pname:systemId is the basetype:XrSystemId of the current system 
 * pname:listenInfo is the slink:XrRemotingListenInfoMSFT properties/settings to use for the connection
 ****
 
@@ -373,7 +417,7 @@ include::../../../../generated/api/protos/xrRemotingDisconnectMSFT.txt[]
 .Parameter Descriptions
 ****
 * pname:instance is the handle of the instance from which to get the information
-* pname:systemId is the slink:XrSystemId of the current system 
+* pname:systemId is the basetype:XrSystemId of the current system 
 * pname:disconnectInfo is the slink:XrRemotingDisconnectInfoMSFT settings to use while closing current connection
 ****
 
@@ -382,7 +426,7 @@ include::../../../../generated/validity/protos/xrRemotingDisconnectMSFT.txt[]
 
 *Returns the current connection state*
 
-[open,refpage='xrRemotingGetConnectionStateMSFT',type='protos',desc='Returns the current connection state',xrefs='XrRemotingConnectionStateMSFT, XrRemotingDisconnectReasonMSFT']
+[open,refpage='xrRemotingGetConnectionStateMSFT',type='protos',desc='Returns the current connection state',xrefs='XrRemotingConnectionStateMSFT XrRemotingDisconnectReasonMSFT']
 --
 
 include::../../../../generated/api/protos/xrRemotingGetConnectionStateMSFT.txt[]
@@ -390,7 +434,7 @@ include::../../../../generated/api/protos/xrRemotingGetConnectionStateMSFT.txt[]
 .Parameter Descriptions
 ****
 * pname:instance is the handle of the instance from which to get the information
-* pname:systemId is the slink:XrSystemId of the current system 
+* pname:systemId is the basetype:XrSystemId of the current system 
 * pname:connectionState is the current connection state elink:XrRemotingConnectionStateMSFT
 * pname:lastDisconnectReason is the last elink:XrRemotingDisconnectReasonMSFT
 ****
@@ -408,7 +452,7 @@ include::../../../../generated/api/protos/xrRemotingSetSecureConnectionClientCal
 .Parameter Descriptions
 ****
 * pname:instance is the handle of the instance from which to get the information
-* pname:systemId is the slink:XrSystemId of the current system 
+* pname:systemId is the basetype:XrSystemId of the current system 
 * pname:secureConnectionClientCallbacks is the callback interfaces that needs to be passed for the client network context
 ****
 
@@ -425,7 +469,7 @@ include::../../../../generated/api/protos/xrRemotingSetSecureConnectionServerCal
 .Parameter Descriptions
 ****
 * pname:instance is the handle of the instance from which to get the information
-* pname:systemId is the slink:XrSystemId of the current system 
+* pname:systemId is the basetype:XrSystemId of the current system 
 * pname:secureConnectionServerCallbacks is the callback interfaces that needs to be passed for the server network context
 ****
 
@@ -534,10 +578,10 @@ include::../../../../generated/api/enums/XrRemotingVideoCodecMSFT.txt[]
 
 .Enumerant Descriptions
 ****
-* ename:XR_REMOTING_VIDEO_CODEC_ANY represents HEVC video codec preferred,
+* ename:XR_REMOTING_VIDEO_CODEC_ANY_MSFT represents HEVC video codec preferred,
   fall back to H264 if HEVC is not supported by all participants.
-* ename:XR_REMOTING_VIDEO_CODEC_H264 represents H264 video codec.
-* ename:XR_REMOTING_VIDEO_CODEC_H265 represents HEVC video codec.
+* ename:XR_REMOTING_VIDEO_CODEC_H264_MSFT represents H264 video codec.
+* ename:XR_REMOTING_VIDEO_CODEC_H265_MSFT represents HEVC video codec.
 ****
 
 --
@@ -545,17 +589,17 @@ include::../../../../generated/api/enums/XrRemotingVideoCodecMSFT.txt[]
 [open,refpage='XrRemotingCertificateNameMismatchMSFT',type='enums',desc='Describes whether the name of the host presenting the certificate does not match the certificate subject',xrefs='']
 --
 The elink:XrRemotingCertificateNameMismatchMSFT describes whether the name of the host presenting the certificate does not match the certificate subject 
-or if the the name match cannot be reliably determined.
+or if the name match cannot be reliably determined.
 
 include::../../../../generated/api/enums/XrRemotingCertificateNameMismatchMSFT.txt[]
 
 .Enumerant Descriptions
 ****
-* ename:XR_REMOTING_CERTIFICATE_NAME_NOT_CHECKED represents that the
+* ename:XR_REMOTING_CERTIFICATE_NAME_MISMATCH_NOT_CHECKED_MSFT represents that the
   name match cannot be reliably determined.
-* ename:XR_REMOTING_CERTIFICATE_NAME_MATCH represents the name of the 
+* ename:XR_REMOTING_CERTIFICATE_NAME_MISMATCH_MATCH_MSFT represents the name of the 
   host presenting the certificate matches the certificate subject.
-* ename:XR_REMOTING_CERTIFICATE_NAME_MISMATCH represents the name of the 
+* ename:XR_REMOTING_CERTIFICATE_NAME_MISMATCH_MISMATCH_MSFT represents the name of the 
   host presenting the certificate does not match the certificate subject.
 ****
 

--- a/specification/sources/chapters/extensions/msft/msft_remoting_frame_mirroring.adoc
+++ b/specification/sources/chapters/extensions/msft/msft_remoting_frame_mirroring.adoc
@@ -19,8 +19,8 @@ and can be used for local display.
 [open,refpage='XrRemotingFrameMirrorImageBaseHeaderMSFT',desc='Base structure that can be overridden by a graphics API-specific XrRemotingFrameMirrorImage* child structure',type='structs',xrefs='XR_TYPE_REMOTING_FRAME_MIRROR_IMAGE_D3D11_MSFT XR_TYPE_REMOTING_FRAME_MIRROR_IMAGE_D3D12_MSFT']
 --
 The slink:XrRemotingFrameMirrorImageBaseHeaderMSFT is a base structure that can be overridden by a 
-graphics API-specific XrRemotingFrameMirrorImage* child structure. The type must be one of the following XrStructureType values:
-slink:XR_TYPE_REMOTING_FRAME_MIRROR_IMAGE_D3D11_MSFT, slink:XR_TYPE_REMOTING_FRAME_MIRROR_IMAGE_D3D12_MSFT
+graphics API-specific XrRemotingFrameMirrorImage* child structure. The type must be one of the following elink:XrStructureType values:
+ename:XR_TYPE_REMOTING_FRAME_MIRROR_IMAGE_D3D11_MSFT, ename:XR_TYPE_REMOTING_FRAME_MIRROR_IMAGE_D3D12_MSFT
 
 The slink:XrRemotingFrameMirrorImageBaseHeaderMSFT structure is defined as:
 
@@ -34,6 +34,9 @@ include::../../../../generated/api/structs/XrRemotingFrameMirrorImageBaseHeaderM
   No such structures are defined in core OpenXR or this extension.
 ****
 
+include::../../../../generated/validity/structs/XrRemotingFrameMirrorImageBaseHeaderMSFT.txt[]
+--
+
 [open,refpage='XrRemotingFrameMirrorImageD3D11MSFT',desc='Provides a D3D11 texture to copy the final composited frame into.',type='structs',xrefs='XR_TYPE_REMOTING_FRAME_MIRROR_IMAGE_D3D11_MSFT']
 --
 The slink:XrRemotingFrameMirrorImageD3D11MSFT structure is defined as:
@@ -46,8 +49,6 @@ The following are the constraints to be mindful of:
 - The texture must be in one of these format: DXGI_FORMAT_B8G8R8A8_UNORM_SRGB, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_FORMAT_R8G8B8A8_UNORM
 - The texture must not be an array texture.
 
-include::../../../../generated/validity/structs/XrRemotingFrameMirrorImageD3D11MSFT.txt[]
-
 .Member Descriptions
 ****
 * pname:type is the elink:XrStructureType of this structure.
@@ -56,6 +57,10 @@ include::../../../../generated/validity/structs/XrRemotingFrameMirrorImageD3D11M
   No such structures are defined in core OpenXR or this extension.
 * pname:texture is a pointer to a valid ID3D11Texture2D to use.
 ****
+
+include::../../../../generated/validity/structs/XrRemotingFrameMirrorImageD3D11MSFT.txt[]
+
+--
 
 [open,refpage='XrRemotingFrameMirrorImageD3D12MSFT',desc='Provides a D3D12 texture to copy the final composited frame into.',type='structs',xrefs='XR_TYPE_REMOTING_FRAME_MIRROR_IMAGE_D3D12_MSFT']
 --
@@ -70,8 +75,6 @@ The following are the constraints to be mindful of:
 - The texture must not be an array texture.
 - The resource states must be compatible with color textures.
 
-include::../../../../generated/validity/structs/XrRemotingFrameMirrorImageD3D12MSFT.txt[]
-
 .Member Descriptions
 ****
 * pname:type is the elink:XrStructureType of this structure.
@@ -83,11 +86,14 @@ include::../../../../generated/validity/structs/XrRemotingFrameMirrorImageD3D12M
 * pname:stateAfter is the "after" usages of the texture when the frame mirror image copy is complete, as a bitwise-OR'd combination of D3D12_RESOURCE_STATES enumeration constants.
 ****
 
+include::../../../../generated/validity/structs/XrRemotingFrameMirrorImageD3D12MSFT.txt[]
+--
+
 [open,refpage='XrRemotingFrameMirrorImageInfoMSFT',desc='Used to attach a texture target for the frame mirroring to the XrFrameEndInfo structure',type='structs',xrefs='XR_TYPE_REMOTING_FRAME_MIRROR_IMAGE_INFO_MSFT']
 --
-The application can submit frame mirror images for the primary view configuration using the slink:xrEndFrame function, 
-by chaining the slink:XrRemotingFrameMirrorImageInfoMSFT structure to the next pointer of XrFrameEndInfo structure.
-Once xrEndFrame has returned, work using the API-specific texture can be scheduled on the device provided by the application without need for additional GPU synchronization.
+The application can submit frame mirror images for the primary view configuration using the flink:xrEndFrame function, 
+by chaining the slink:XrRemotingFrameMirrorImageInfoMSFT structure to the next pointer of slink:XrFrameEndInfo structure.
+Once flink:xrEndFrame has returned, work using the API-specific texture can be scheduled on the device provided by the application without need for additional GPU synchronization.
 		
 The slink:XrRemotingFrameMirrorImageInfoMSFT structure is defined as:
 
@@ -99,8 +105,11 @@ include::../../../../generated/api/structs/XrRemotingFrameMirrorImageInfoMSFT.tx
 * pname:next is code:NULL or a pointer to the next structure in a structure
   chain.
   No such structures are defined in core OpenXR or this extension.
-* pname:image is a API-agnostic pointer to a API-specific slink:XrRemotingFrameMirrorImage* structure based off of slink:XrRemotingFrameMirrorImageBaseHeaderMSFT.
+* pname:image is a API-agnostic pointer to a API-specific stext:XrRemotingFrameMirrorImage* structure based off of slink:XrRemotingFrameMirrorImageBaseHeaderMSFT.
 ****
+
+include::../../../../generated/validity/structs/XrRemotingFrameMirrorImageInfoMSFT.txt[]
+--
 
 *New Object Types*
 


### PR DESCRIPTION
1. (fixed) <command lacks errorcodes attribute
2. (fixed) <type ... lacks structextends attribute
3. (fixed) XrRemotingVideoCodecMSFT
4. (fixed, need revised) XrRemotingCertificateNameMismatchMSFT
    XR_REMOTING_CERTIFICATE_NAME_MISMATCH_MISMATCH_MSFT
5. (blocked) following PFN types are never defined.
 - PFN_xrRemotingRequestAuthenticationTokenCallbackMSFT
 - PFN_xrRemotingValidateServerCertificateCallbackMSFT
 - PFN_xrRemotingRequestServerCertificateCallbackMSFT
 - PFN_xrRemotingValidateAuthenticationTokenCallbackMSFT